### PR TITLE
Create .gitattributes and ignore ipynb

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb -linguist-detectable


### PR DESCRIPTION
This will tell github to not count ipynb as part of the repo's languages

See: https://stackoverflow.com/questions/72898768/gitlab-remove-notebooks-from-language-percentage